### PR TITLE
Add a viewport declaration; improve mobile view

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -75,6 +75,7 @@
    [:html
     [:head
      [:title title]
+     [:meta {:name "viewport" :content "width=device-width"}]
      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
     [:body
      (title-block title)
@@ -103,6 +104,7 @@
      [:html
       [:head
        [:title title]
+       [:meta {:name "viewport" :content "width=device-width"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body
        (title-block title)


### PR DESCRIPTION
Makes the site a lot more readable on phones - for example, here’s the live site and this branch shown on a 4-inch iPhone;

![ios simulator screen shot 16 jun 2015 6 29 36 pm](https://cloud.githubusercontent.com/assets/282113/8178918/f2284428-1455-11e5-86a0-c4f2eeead9df.png)