### PR TITLE
Remove invalid CSS, add generic to font stack

### DIFF
--- a/resources/pronouns.css
+++ b/resources/pronouns.css
@@ -1,40 +1,34 @@
 body {
-	font-family: futura;
-	font: large;
-	background-color:#F6CEFC;
+	font-family: Futura, sans-serif;
+	background-color: #F6CEFC;
 }
 
 .examples {
-	font: large;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
-	border:4px solid #eeeeee;
+	border: 4px solid #eeeeee;
 }
 
 .title {
-	font: large;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
-	border:4px solid #eeeeee;
+	border: 4px solid #eeeeee;
 }
 
 .about {
-	font: large;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
-	border:4px solid #eeeeee;
+	border: 4px solid #eeeeee;
 }
 
 .contact {
-	font: large;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
-	border:4px solid #eeeeee;
+	border: 4px solid #eeeeee;
 }
 
 .table {
-	font: large;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
-	border:4px solid #eeeeee;
+	border: 4px solid #eeeeee;
 }


### PR DESCRIPTION
`large` is not a valid `font` property, and this makes no change to the rendering of the site.
Added `sans-serif` to the end of the font stack to avoid falling back to a serif font on systems without Futura installed.