### PR TITLE
Custom pronoun form

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,8 @@
                  [ring-basic-authentication "1.0.5"]
                  [environ "0.5.0"]
                  [hiccup "1.0.5"]
-                 [com.cemerick/drawbridge "0.0.6"]]
+                 [com.cemerick/drawbridge "0.0.6"]
+                 [org.clojure/data.json "0.2.6"]]
   :min-lein-version "2.0.0"
   :plugins [[environ/environ.lein "0.2.1"]]
   :hooks [environ.leiningen.hooks]

--- a/resources/custom-pronouns.js
+++ b/resources/custom-pronouns.js
@@ -1,0 +1,181 @@
+(function () {
+  'use strict';
+
+  var urlRoot = 'http://pronoun.is/',
+    urlParams = ['subject', 'object', 'possessive-determiner', 'possessive-pronoun', 'reflexive'];
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // Only show the custom pronoun form if js is enabled and we've got a modern-ish browser
+    document.body.classList.add('js');
+    setup();
+  }, false)
+
+  var form,
+    refers,
+    urlLink,
+    defaultPronouns = {},
+    pronouns = {};
+
+  function setup() {
+    form = document.querySelector('.custom-pronoun form');
+    refers = [].slice.call(form.querySelectorAll('[data-refer]'));
+    urlLink = document.querySelector('.custom-pronoun .url');
+
+    [].slice.call(form.querySelectorAll('[name]')).forEach(function (el) {
+      defaultPronouns[el.name] = el.getAttribute('placeholder');
+    });
+
+    form.addEventListener('input', handleFormInput, false);
+    form.addEventListener('change', handleFormInput, false);
+  }
+
+  function handleFormInput(event) {
+    var input = event.target,
+      name = input.name,
+      value = input.value.trim().toLowerCase() || null;
+
+    pronouns[name] = value;
+    updateRefers(name, value);
+    update(pronouns);
+  }
+
+  function update(pronouns) {
+    var sections = urlSections(urlParams, pronouns);
+    if (sections.length >= urlParams.length) {
+      var url = formatUrl(urlRoot, urlParams, pronouns);
+      showURL(url);
+      return;
+    }
+
+    if (sections.length >= 1) {
+      checkDatabase(clone(pronouns));
+    }
+
+    hideURL();
+  }
+
+  var checkDatabase = debounce(300, function (pronouns) {
+    var url = formatUrl('/', urlParams, pronouns);
+    if (url === '/') return;
+
+    getJSON(url, function (err, dbPronouns) {
+      if (err) {
+        // Ignore errors loading suggested pronouns from the server,
+        // the user can just fill out the form manually
+        return null;
+      }
+
+      dbPronouns.forEach(function (pronoun, i) {
+        var name = urlParams[i];
+        updatePlaceholder(name, pronoun);
+        defaultPronouns[name] = pronoun;
+      });
+
+      showURL(formatUrl(urlRoot, urlParams, pronouns));
+    });
+  });
+
+  // DOM mutation stuff
+  function updateRefers(name, value) {
+    refers
+      .filter(function (el) {
+        return el.getAttribute('data-refer') === name;
+      })
+      .forEach(function (el) {
+        var pronoun = value || defaultPronouns[name];
+        el.textContent = el.getAttribute('data-capitalize') ? capitalize(pronoun) : pronoun;
+      });
+  }
+
+  function updatePlaceholder(name, value) {
+    form[name].setAttribute('placeholder', value);
+  }
+
+  function showURL(url) {
+    urlLink.style.display = 'initial';
+    urlLink.href = url;
+    urlLink.textContent = url;
+  }
+
+  function hideURL() {
+    urlLink.style.display = 'none';
+  }
+
+  // URL formatting stuff
+  function urlSections(urlParams, data) {
+    var sections = urlParams.map(function(param) {
+      return data[param];
+    });
+
+    return takeWhile(sections, function(param) {
+      return param != null;
+    });
+  }
+
+  function formatUrl(urlRoot, urlParams, data) {
+    return urlRoot + urlSections(urlParams, data).join('/');
+  }
+
+  // Utils:
+  function takeWhile(arr, predicate) {
+    var newArr = [];
+
+    while(predicate(arr[newArr.length])) {
+      newArr.push(arr[newArr.length]);
+    }
+
+    return newArr;
+  }
+
+  function debounce(timeout, fn) {
+    var id;
+    return function() {
+      var args = arguments;
+      clearTimeout(id);
+      id = setTimeout(function() {
+        fn.apply(null, args);
+      }, timeout);
+    }
+  }
+
+  function capitalize(str) {
+    var chars = str.split(''),
+      first = chars[0].toUpperCase();
+
+    chars[0] = first;
+    return chars.join('');
+  }
+
+  function clone(obj) {
+    var newObj = {};
+    for (var key in obj) {
+      if (obj.hasOwnProperty(key)) {
+        newObj[key] = obj[key];
+      }
+    }
+    return newObj;
+  }
+
+  function getJSON(url, callback) {
+    var req = new XMLHttpRequest();
+
+    req.addEventListener('load', function() {
+      var json;
+      try {
+        json = JSON.parse(req.responseText);
+      } catch(e) {
+        callback(e);
+        return;
+      }
+      callback(null, json);
+    }, false);
+
+    req.addEventListener('error', function() {
+      callback(req);
+    }, false);
+
+    req.open("GET", url);
+    req.setRequestHeader('Accept', 'application/json');
+    req.send();
+  }
+}());

--- a/resources/custom-pronouns.js
+++ b/resources/custom-pronouns.js
@@ -21,6 +21,10 @@
     refers = arrayFrom(form.querySelectorAll('[data-refer]'));
     urlLink = document.querySelector('.custom-pronoun .url');
 
+    form.addEventListener('submit', function (event) {
+      event.preventDefault();
+    }, false);
+
     arrayFrom(form.querySelectorAll('[name]')).forEach(function (el) {
       defaultPronouns[el.name] = (el.getAttribute('placeholder') || '').trim().toLowerCase();
       pronouns[el.name] = el.value.trim().toLowerCase() || null;

--- a/resources/custom-pronouns.js
+++ b/resources/custom-pronouns.js
@@ -18,11 +18,12 @@
 
   function setup() {
     form = document.querySelector('.custom-pronoun form');
-    refers = [].slice.call(form.querySelectorAll('[data-refer]'));
+    refers = arrayFrom(form.querySelectorAll('[data-refer]'));
     urlLink = document.querySelector('.custom-pronoun .url');
 
-    [].slice.call(form.querySelectorAll('[name]')).forEach(function (el) {
-      defaultPronouns[el.name] = el.getAttribute('placeholder');
+    arrayFrom(form.querySelectorAll('[name]')).forEach(function (el) {
+      defaultPronouns[el.name] = (el.getAttribute('placeholder') || '').trim().toLowerCase();
+      pronouns[el.name] = el.value.trim().toLowerCase() || null;
     });
 
     form.addEventListener('input', handleFormInput, false);
@@ -82,7 +83,7 @@
         return el.getAttribute('data-refer') === name;
       })
       .forEach(function (el) {
-        var pronoun = value || defaultPronouns[name];
+        var pronoun = value || defaultPronouns[name] || '';
         el.textContent = el.getAttribute('data-capitalize') ? capitalize(pronoun) : pronoun;
       });
   }
@@ -104,7 +105,9 @@
   // URL formatting stuff
   function urlSections(urlParams, data) {
     var sections = urlParams.map(function(param) {
-      return data[param];
+      if (data[param]) {
+        return encodeURIComponent(data[param]);
+      }
     });
 
     return takeWhile(sections, function(param) {
@@ -139,6 +142,8 @@
   }
 
   function capitalize(str) {
+    if (str.length === 0) return str;
+
     var chars = str.split(''),
       first = chars[0].toUpperCase();
 
@@ -167,7 +172,11 @@
         callback(e);
         return;
       }
-      callback(null, json);
+      if (req.status !== 200 || json.error) {
+        callback(json, null);
+      } else {
+        callback(null, json);
+      }
     }, false);
 
     req.addEventListener('error', function() {
@@ -177,5 +186,9 @@
     req.open("GET", url);
     req.setRequestHeader('Accept', 'application/json');
     req.send();
+  }
+
+  function arrayFrom(arrayLike) {
+    return [].slice.call(arrayLike);
   }
 }());

--- a/resources/pronouns.css
+++ b/resources/pronouns.css
@@ -32,3 +32,23 @@ body {
 	padding: 4px 6px 4px 6px;
 	border: 4px solid #eeeeee;
 }
+
+.custom-pronoun {
+	display: none;
+	margin: 8px;
+	padding: 4px 6px 4px 6px;
+	border: 4px solid #eeeeee;
+}
+
+.js .custom-pronoun {
+	display: block;
+}
+
+input {
+	background: #FBE7FE;
+	border: none;
+	border-bottom: 1px dotted black;
+	font-family: inherit;
+	font-size: inherit;
+	width: 7em;
+}

--- a/resources/pronouns.css
+++ b/resources/pronouns.css
@@ -34,14 +34,21 @@ body {
 }
 
 .custom-pronoun {
-	display: none;
 	margin: 8px;
 	padding: 4px 6px 4px 6px;
 	border: 4px solid #eeeeee;
 }
 
-.js .custom-pronoun {
-	display: block;
+.custom-pronoun [data-refer] {
+  display: none;
+}
+
+.js .custom-pronoun [data-refer] {
+  display: inline;
+}
+
+.js .custom-pronoun button {
+  display: none;
 }
 
 input {
@@ -51,4 +58,21 @@ input {
 	font-family: inherit;
 	font-size: inherit;
 	width: 7em;
+}
+
+button {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.warning {
+  display: inline-block;
+  margin: 0;
+  padding: 6px;
+  background: #FCEAB5;
+  border: 2px solid #CABB91;
+}
+
+.error {
+  color: #C2002E;
 }

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -9,12 +9,24 @@
   [pronoun]
   [:b pronoun])
 
+(declare capitalize)
+(defn capitalize-html [[name attrs content]]
+  (if (= :input name)
+    [name (update-in attrs [:placeholder] capitalize) content]
+    [name (assoc attrs :data-capitalize true) (capitalize content)]))
+
+(defn capitalize [html]
+  (cond
+    (string? html) (s/capitalize html)
+    (vector? html) (capitalize-html html)
+    :else html))
+
 (defn render-sentence [& content]
   [:p [:span.sentence content]])
 
 (defn subject-example
   [subject]
-  (render-sentence (wrap-pronoun (s/capitalize subject)) " went to the park."))
+  (render-sentence (wrap-pronoun (capitalize subject)) " went to the park."))
 
 (defn object-example
   [object]
@@ -22,7 +34,7 @@
 
 (defn posessive-determiner-example
   [subject possessive-determiner]
-  (render-sentence (wrap-pronoun (s/capitalize subject))
+  (render-sentence (wrap-pronoun (capitalize subject))
                    " brought "
                    (wrap-pronoun possessive-determiner)
                    " frisbee."))
@@ -33,7 +45,7 @@
 
 (defn reflexive-example
   [subject reflexive]
-  (render-sentence (wrap-pronoun (s/capitalize subject))
+  (render-sentence (wrap-pronoun (capitalize subject))
                    " threw the frisbee to "
                    (wrap-pronoun reflexive)
                    "."))
@@ -51,6 +63,21 @@
    (posessive-determiner-example subject possessive-determiner)
    (possessive-pronoun-example possessive-pronoun)
    (reflexive-example subject reflexive)])
+
+(defn custom-pronoun-block [subject object possessive-determiner possessive-pronoun reflexive]
+  [:div {:class "custom-pronoun"}
+   [:p "Fill out the example to create a link for your own pronouns: "
+       [:a {:class "url"}]]
+   [:form
+    (subject-example [:input {:name "subject" :placeholder subject}])
+    (object-example [:input {:name "object" :placeholder object}])
+    (posessive-determiner-example
+      [:span {:data-refer "subject"} subject]
+      [:input {:name "possessive-determiner" :placeholder possessive-determiner}])
+    (possessive-pronoun-example [:input {:name "possessive-pronoun" :placeholder possessive-pronoun}])
+    (reflexive-example
+      [:span {:data-refer "subject"} subject]
+      [:input {:name "reflexive" :placeholder reflexive}])]])
 
 (defn about-block []
   [:div {:class "about"}
@@ -118,8 +145,10 @@
        [:div {:class "table"}
         [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
         [:p "here are some pronouns the site knows about:"]
-        [:ul links]]]
-      (contact-block)])))
+        [:ul links]]
+       (apply custom-pronoun-block (rand-nth pronouns-table))
+       (contact-block)
+       [:script {:src "/custom-pronouns.js"}]]])))
 
 (defn not-found []
   (str "We couldn't find those pronouns in our database, please ask us to "

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -12,7 +12,9 @@
 (declare capitalize)
 (defn capitalize-html [[name attrs content]]
   (if (= :input name)
-    [name (update-in attrs [:placeholder] capitalize) content]
+    [name (-> attrs
+            (update-in [:placeholder] capitalize)
+            (update-in [:value] capitalize)) content]
     [name (assoc attrs :data-capitalize true) (capitalize content)]))
 
 (defn capitalize [html]
@@ -64,20 +66,20 @@
    (possessive-pronoun-example possessive-pronoun)
    (reflexive-example subject reflexive)])
 
-(defn custom-pronoun-block [subject object possessive-determiner possessive-pronoun reflexive]
+(defn custom-pronoun-block
+  [msg input-type [subject object possessive-determiner possessive-pronoun reflexive]]
   [:div {:class "custom-pronoun"}
-   [:p "Fill out the example to create a link for your own pronouns: "
-       [:a {:class "url"}]]
+   [:p msg " " [:a {:class "url"}]]
    [:form
-    (subject-example [:input {:name "subject" :placeholder subject}])
-    (object-example [:input {:name "object" :placeholder object}])
+    (subject-example [:input {:name "subject" input-type subject}])
+    (object-example [:input {:name "object" input-type object}])
     (posessive-determiner-example
       [:span {:data-refer "subject"} subject]
-      [:input {:name "possessive-determiner" :placeholder possessive-determiner}])
-    (possessive-pronoun-example [:input {:name "possessive-pronoun" :placeholder possessive-pronoun}])
+      [:input {:name "possessive-determiner" input-type possessive-determiner}])
+    (possessive-pronoun-example [:input {:name "possessive-pronoun" input-type possessive-pronoun}])
     (reflexive-example
       [:span {:data-refer "subject"} subject]
-      [:input {:name "reflexive" :placeholder reflexive}])]])
+      [:input {:name "reflexive" input-type reflexive}])]])
 
 (defn about-block []
   [:div {:class "about"}
@@ -113,10 +115,8 @@
       (about-block)
       (contact-block)]])))
 
-
-(defn format-pronoun-json [pronouns]
+(defn format-pronoun-json [& pronouns]
   (json/write-str pronouns))
-
 
 (defn parse-pronouns-with-lookup [pronouns-string pronouns-table]
   (let [inputs (s/split pronouns-string #"/")
@@ -146,19 +146,43 @@
         [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
         [:p "here are some pronouns the site knows about:"]
         [:ul links]]
-       (apply custom-pronoun-block (rand-nth pronouns-table))
+       (custom-pronoun-block
+         "Fill out the example to create a link to your own pronouns:"
+         :placeholder (rand-nth pronouns-table))
        (contact-block)
        [:script {:src "/custom-pronouns.js"}]]])))
 
-(defn not-found []
-  (str "We couldn't find those pronouns in our database, please ask us to "
-       "add them, or issue a pull request at "
-       "https://github.com/witch-house/pronoun.is/blob/master/resources/pronouns.tab"))
+(defn not-found [path]
+  (let [pronouns (s/split path #"/")
+        title "Pronoun Island: Not Found"
+        db-url "https://github.com/witch-house/pronoun.is/blob/master/resources/pronouns.tab"]
+    (html
+     [:html
+      [:head
+       [:title title]
+       [:meta {:name "viewport" :content "width=device-width"}]
+       [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+      [:body
+       (title-block title)
+       (custom-pronoun-block
+         [:span "We couldn't find those pronouns in our database. Please ask us "
+          "to add them, " [:a {:href db-url} "issue a pull request"] ", "
+          "or fill out the example for a link to a set of custom pronouns:"]
+         :value (u/pad-pronouns pronouns))
+       (about-block)
+       (contact-block)
+       [:script {:src "/custom-pronouns.js"}]]])))
 
-(defn pronouns [path pronouns-table accept]
+(defn not-found-json [path]
+  (json/write-str {:error "Not found"}))
+
+(defn pronouns-page [path pronouns-table format-pronouns not-found]
   (let [pronouns (parse-pronouns-with-lookup (escape-html path) pronouns-table)]
     (if pronouns
-      (if (= accept :json)
-        (format-pronoun-json pronouns)
-        (apply format-pronoun-examples pronouns))
-      (not-found))))
+      (apply format-pronouns pronouns)
+      (not-found path))))
+
+(defn pronouns [path pronouns-table accept]
+  (if (= accept :json)
+    (pronouns-page path pronouns-table format-pronoun-json not-found-json)
+    (pronouns-page path pronouns-table format-pronoun-examples not-found)))

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -90,30 +90,30 @@
 
 (defn contact-block []
   (let [twitter-name (fn [handle] [:a {:href (str "https://www.twitter.com/" handle)} (str "@" handle)])]
-   [:div {:class "contact"}
-    [:p
-     "Written by "
-     (twitter-name "morganastra")
-     ", whose "
-     [:a {:href "http://pronoun.is/ze/zir"} "pronoun.is/ze/zir"]
-     ". "
-     "Visit the project on " [:a {:href "https://github.com/witch-house/pronoun.is"} "github!"]]]))
+  [:div {:class "contact"}
+   [:p
+    "Written by "
+    (twitter-name "morganastra")
+    ", whose "
+    [:a {:href "http://pronoun.is/ze/zir"} "pronoun.is/ze/zir"]
+    ". "
+   "Visit the project on " [:a {:href "https://github.com/witch-house/pronoun.is"} "github!"]]]))
 
 
 (defn format-pronoun-examples
   [subject object possessive-determiner possessive-pronoun reflexive]
   (let [title "Pronoun Island: English Language Examples"]
-   (html
-    [:html
-     [:head
-      [:title title]
-      [:meta {:name "viewport" :content "width=device-width"}]
-      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-     [:body
-      (title-block title)
-      (examples-block subject object possessive-determiner possessive-pronoun reflexive)
-      (about-block)
-      (contact-block)]])))
+  (html
+   [:html
+    [:head
+     [:title title]
+     [:meta {:name "viewport" :content "width=device-width"}]
+     [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+    [:body
+     (title-block title)
+     (examples-block subject object possessive-determiner possessive-pronoun reflexive)
+     (about-block)
+     (contact-block)]])))
 
 (defn format-pronoun-json [& pronouns]
   (json/write-str pronouns))
@@ -143,9 +143,9 @@
       [:body
        (title-block title)
        [:div {:class "table"}
-        [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
-        [:p "here are some pronouns the site knows about:"]
-        [:ul links]]
+       [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
+       [:p "here are some pronouns the site knows about:"]
+       [:ul links]]
        (custom-pronoun-block
          "Fill out the example to create a link to your own pronouns:"
          :placeholder (rand-nth pronouns-table))

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -1,5 +1,6 @@
 (ns pronouns.pages
   (:require [clojure.string :as s]
+            [clojure.data.json :as json]
             [pronouns.util :as u]
             [hiccup.core :refer :all]
             [hiccup.util :refer [escape-html]]))
@@ -60,30 +61,34 @@
 
 (defn contact-block []
   (let [twitter-name (fn [handle] [:a {:href (str "https://www.twitter.com/" handle)} (str "@" handle)])]
-  [:div {:class "contact"}
-   [:p
-    "Written by "
-    (twitter-name "morganastra")
-    ", whose "
-    [:a {:href "http://pronoun.is/ze/zir"} "pronoun.is/ze/zir"]
-    ". "
-   "Visit the project on " [:a {:href "https://github.com/witch-house/pronoun.is"} "github!"]]]))
+   [:div {:class "contact"}
+    [:p
+     "Written by "
+     (twitter-name "morganastra")
+     ", whose "
+     [:a {:href "http://pronoun.is/ze/zir"} "pronoun.is/ze/zir"]
+     ". "
+     "Visit the project on " [:a {:href "https://github.com/witch-house/pronoun.is"} "github!"]]]))
 
 
 (defn format-pronoun-examples
   [subject object possessive-determiner possessive-pronoun reflexive]
   (let [title "Pronoun Island: English Language Examples"]
-  (html
-   [:html
-    [:head
-     [:title title]
-     [:meta {:name "viewport" :content "width=device-width"}]
-     [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-    [:body
-     (title-block title)
-     (examples-block subject object possessive-determiner possessive-pronoun reflexive)
-     (about-block)
-     (contact-block)]])))
+   (html
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (title-block title)
+      (examples-block subject object possessive-determiner possessive-pronoun reflexive)
+      (about-block)
+      (contact-block)]])))
+
+
+(defn format-pronoun-json [pronouns]
+  (json/write-str pronouns))
 
 
 (defn parse-pronouns-with-lookup [pronouns-string pronouns-table]
@@ -111,9 +116,9 @@
       [:body
        (title-block title)
        [:div {:class "table"}
-       [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
-       [:p "here are some pronouns the site knows about:"]
-       [:ul links]]]
+        [:p "pronoun.is is a www site for showing people how to use pronouns in English."]
+        [:p "here are some pronouns the site knows about:"]
+        [:ul links]]]
       (contact-block)])))
 
 (defn not-found []
@@ -121,8 +126,10 @@
        "add them, or issue a pull request at "
        "https://github.com/witch-house/pronoun.is/blob/master/resources/pronouns.tab"))
 
-(defn pronouns [path pronouns-table]
+(defn pronouns [path pronouns-table accept]
   (let [pronouns (parse-pronouns-with-lookup (escape-html path) pronouns-table)]
     (if pronouns
-      (apply format-pronoun-examples pronouns)
+      (if (= accept :json)
+        (format-pronoun-json pronouns)
+        (apply format-pronoun-examples pronouns))
       (not-found))))

--- a/src/pronouns/util.clj
+++ b/src/pronouns/util.clj
@@ -34,3 +34,15 @@
   (if (> 5 (count pronouns))
     (pad-pronouns (conj pronouns ""))
     pronouns))
+
+(defn complete?
+  "does this list of pronouns contain a pronoun for every case?"
+  [pronouns]
+  (= 5 (count (filter string? pronouns))))
+
+(defn format-pronoun [pronoun]
+  (let [p (.toLowerCase (s/trim pronoun))]
+    (if (= "" p)
+      nil
+      p)))
+

--- a/src/pronouns/util.clj
+++ b/src/pronouns/util.clj
@@ -18,12 +18,12 @@
 (defn minimum-unambiguous-path
   ([pronouns-table sections] (minimum-unambiguous-path pronouns-table sections 1))
   ([pronouns-table sections number-of-sections]
-    (let [sections-subset (take number-of-sections sections)
-          results (filter #(= (take number-of-sections %) sections-subset) pronouns-table)]
-      (case (count results)
-        0 nil
-        1 (clojure.string/join "/" sections-subset)
-        (recur pronouns-table sections (+ number-of-sections 1))))))
+   (let [sections-subset (take number-of-sections sections)
+         results (filter #(= (take number-of-sections %) sections-subset) pronouns-table)]
+     (case (count results)
+       0 nil
+       1 (clojure.string/join "/" sections-subset)
+       (recur pronouns-table sections (+ number-of-sections 1))))))
 
 (defn abbreviate
   "given a list of pronoun rows, return a list of minimum unabiguous paths"

--- a/src/pronouns/util.clj
+++ b/src/pronouns/util.clj
@@ -18,12 +18,12 @@
 (defn minimum-unambiguous-path
   ([pronouns-table sections] (minimum-unambiguous-path pronouns-table sections 1))
   ([pronouns-table sections number-of-sections]
-   (let [sections-subset (take number-of-sections sections)
-         results (filter #(= (take number-of-sections %) sections-subset) pronouns-table)]
-     (case (count results)
-       0 nil
-       1 (clojure.string/join "/" sections-subset)
-       (recur pronouns-table sections (+ number-of-sections 1))))))
+    (let [sections-subset (take number-of-sections sections)
+          results (filter #(= (take number-of-sections %) sections-subset) pronouns-table)]
+      (case (count results)
+        0 nil
+        1 (clojure.string/join "/" sections-subset)
+        (recur pronouns-table sections (+ number-of-sections 1))))))
 
 (defn abbreviate
   "given a list of pronoun rows, return a list of minimum unabiguous paths"

--- a/src/pronouns/util.clj
+++ b/src/pronouns/util.clj
@@ -29,3 +29,8 @@
   "given a list of pronoun rows, return a list of minimum unabiguous paths"
   [pronouns-table]
   (map (partial minimum-unambiguous-path pronouns-table) pronouns-table))
+
+(defn pad-pronouns [pronouns]
+  (if (> 5 (count pronouns))
+    (pad-pronouns (conj pronouns ""))
+    pronouns))

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -28,6 +28,11 @@
       :headers {"Content-Type" "text/css"}
       :body (slurp (io/resource "pronouns.css"))})
 
+  (GET "/custom-pronouns.js" []
+       {:status 200
+        :headers {"Content-Type" "application/javascript"}
+        :body (slurp (io/resource "custom-pronouns.js"))})
+
   (GET "/*" {params :params headers :headers}
        (if (= "application/json" (get headers "accept"))
          {:status 200

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -25,8 +25,8 @@
 
   (GET "/pronouns.css" {params :params}
      {:status 200
-      :headers {"Content-Type" "text/css"}
-      :body (slurp (io/resource "pronouns.css"))})
+     :headers {"Content-Type" "text/css"}
+     :body (slurp (io/resource "pronouns.css"))})
 
   (GET "/custom-pronouns.js" []
        {:status 200

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -21,7 +21,7 @@
 (defroutes app-routes
   (GET "/" []
        {:status 200
-        :headers {"Content-Type" "text/html"}
+        :headers {"Content-Type" "text/html; charset=utf-8"}
         :body (pages/front pronouns-table)})
 
   (GET "/pronouns.css" {params :params}
@@ -34,14 +34,14 @@
         :headers {"Content-Type" "application/javascript"}
         :body (slurp (io/resource "custom-pronouns.js"))})
 
-  (GET "/*" {params :params headers :headers}
+  (GET "/*" {uri :uri headers :headers}
        (if (= "application/json" (.toLowerCase (get headers "accept" "*/*")))
          {:status 200
           :headers {"Content-Type" "application/json"}
-          :body (pages/pronouns (:* params) pronouns-table :json)}
+          :body (pages/pronouns uri pronouns-table :json)}
          {:status 200
-          :headers {"Content-Type" "text/html"}
-          :body (pages/pronouns (:* params) pronouns-table :html)}))
+          :headers {"Content-Type" "text/html; charset=utf-8"}
+          :body (pages/pronouns uri pronouns-table :html)}))
 
   (POST "/custom-link" {form :form-params}
         (pages/custom-pronoun-submit form))

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -25,13 +25,17 @@
 
   (GET "/pronouns.css" {params :params}
      {:status 200
-     :headers {"Content-Type" "text/css"}
-     :body (slurp (io/resource "pronouns.css"))})
+      :headers {"Content-Type" "text/css"}
+      :body (slurp (io/resource "pronouns.css"))})
 
-  (GET "/*" {params :params}
-       {:status 200
-        :headers {"Content-Type" "text/html"}
-        :body (pages/pronouns (:* params) pronouns-table)})
+  (GET "/*" {params :params headers :headers}
+       (if (= "application/json" (get headers "accept"))
+         {:status 200
+          :headers {"Content-Type" "application/json"}
+          :body (pages/pronouns (:* params) pronouns-table :json)}
+         {:status 200
+          :headers {"Content-Type" "text/html"}
+          :body (pages/pronouns (:* params) pronouns-table :html)}))
 
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -34,7 +34,7 @@
         :body (slurp (io/resource "custom-pronouns.js"))})
 
   (GET "/*" {params :params headers :headers}
-       (if (= "application/json" (get headers "accept"))
+       (if (= "application/json" (.toLowerCase (get headers "accept" "*/*")))
          {:status 200
           :headers {"Content-Type" "application/json"}
           :body (pages/pronouns (:* params) pronouns-table :json)}

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -8,6 +8,7 @@
             [ring.middleware.stacktrace :as trace]
             [ring.middleware.session :as session]
             [ring.middleware.session.cookie :as cookie]
+            [ring.middleware.params :as params]
             [ring.adapter.jetty :as jetty]
             [environ.core :refer [env]]
             [pronouns.util :as u]
@@ -42,6 +43,9 @@
           :headers {"Content-Type" "text/html"}
           :body (pages/pronouns (:* params) pronouns-table :html)}))
 
+  (POST "/custom-link" {form :form-params}
+        (pages/custom-pronoun-submit form))
+
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))
 
@@ -57,7 +61,8 @@
   (-> app-routes
       logger/wrap-with-logger
       wrap-error-page
-      trace/wrap-stacktrace))
+      trace/wrap-stacktrace
+      params/wrap-params))
 
 (defn -main []
   (let [port (Integer. (:port env


### PR DESCRIPTION
WOOP!

This adds a custom pronoun form on the home page and the 404 page. It also adds a little JSON API (as discussed in #29) which is used to match pronouns already in the database as the form is filled out. On the 404 page, the form is pre-populated with whatever pronouns are already in the URL.

I'm don't have a huge amount of Clojure experience so let me know if there are any problems with this - the stuff for [capitalising](https://github.com/SomeHats/pronoun.is/blob/custom-pronoun-form/src/pronouns/pages.clj#L12-L24) strings/inputs/spans in particular seems dodgy but I'm not sure how to make it better.

Also apparently my editor made a bunch of whitespace changes because computers. I can fix that if needed.
