### PR TITLE
add links to readme for the location of relevant files and dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ That's pretty unwieldy! Fortunately you can also give it only the
 first pronoun or two: http://pronoun.is/she/her or http://pronoun.is/they
 
 Automatically filling in the rest from only one or two forms only
-works for pronouns in the [database](resources/pronouns.tab). If the
+works for pronouns in the [database][pronoun-database]. If the
 pronouns you or a friend uses aren't supported, please let us know and
 we'll add them. Alternatively you could add them yourself and submit a
 pull request (see the next section for details)
@@ -29,7 +29,7 @@ tab characters in that file (a thing your editor might normally be
 configured not to do!) In Emacs, you can input real tabs by doing
 Ctrl+q <tab>
 
-[pronoun-database]: https://github.com/witch-house/pronoun.is/blob/develop/resources/pronouns.tab
+[pronoun-database]: resources/pronouns.tab
 
 ### Running the app in a dev environment
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ pull request (see the next section for details)
 
 ### The database
 
-The pronouns "database" is a tab-delimited file with fields and
-example values as follows:
+The pronouns "database" is a tab-delimited file located in [resources/pronouns.tab][pronoun-database] with fields and example values as follows:
 
 subject|object|possessive-determiner|possessive-pronoun|reflexive
 -------|------|---------------------|------------------|---------
@@ -30,10 +29,12 @@ tab characters in that file (a thing your editor might normally be
 configured not to do!) In Emacs, you can input real tabs by doing
 Ctrl+q <tab>
 
+[pronoun-database]: https://github.com/witch-house/pronoun.is/blob/develop/resources/pronouns.tab
+
 ### Running the app in a dev environment
 
-You can launch the app on your own computer by running the following
-command:
+First, install [leiningen](https://leiningen.org/). Then you can launch the app
+on your own computer by running the following command:
 
 ```
 $ lein ring server


### PR DESCRIPTION
Hello!

I couldn't initially find the file containing all the pronouns, so I thought maybe it would be helpful to document it in the readme!

I also didn't notice a dereference from `lein` to the [leiningen](https://leiningen.org/) project, so I added it. Otherwise, folks without `lein` installed won't have an easy time deciphering how to install whatever `lein` is.