### PR TITLE
Add 'yo' pronoun

### DIFF
--- a/resources/pronouns.tab
+++ b/resources/pronouns.tab
@@ -32,3 +32,4 @@ kit	kit	kits	kits	kitself
 ne	nem	nir	nirs	nemself
 fey	feym	feir	feirs	feirself
 xie	xer	xer	xers	xerself
+yo	yo	yos	yos	yosself


### PR DESCRIPTION
Hello:

This pull request adds the gender-neutral pronoun ‘yo’ to the pronoun.is catalog.

An overview of the pronoun ‘yo’ is available in the NPR article, “[‘Yo’! Baltimore Kids Create a Pronoun](https://www.npr.org/templates/story/story.php?storyId=18567465).“

In 2007, E. Stotko and M. Troyer published the study, “[A New Gender-Neutral Pronoun in Baltimore Maryland](https://read.dukeupress.edu/american-speech/article-abstract/82/3/262/5458/A-NEW-GENDER-NEUTRAL-PRONOUN-IN-BALTIMORE-MARYLAND).” They recorded the use of ‘yo’ among 8th- and 10th-graders in Baltimore, U.S. schools, and noted its use in Milwaukee, U.S. A summary of their results are available in the open-access article, “[Give us a Gender Neutral Pronoun, Yo!](https://dc.etsu.edu/honors/200/)” by E. Elrod.

Stotko and Troyer only recorded the use of ‘yo’ as subject and object pronouns. Since pronoun.is reports possessive determiners, possessive pronouns, and reflexive pronouns, as well, I extrapolated ‘yo’ to [**yo/yo/yos/yos/yosself**](http://pronoun.is/yo/yo/yos/yos/yosself). I used ‘yosself’ instead of ‘[yoself](https://en.wiktionary.org/wiki/yoself),’ which is an eye dialect spelling of ‘yourself.’

While some have objected to the promotion of ‘yo,’ [according to J. Janke](http://wesleyanargus.com/2008/02/08/is-%E2%80%98yo%E2%80%99-the-next-%E2%80%98ze%E2%80%99/), I feel that ‘yo’ is an appropriate addition to pronoun.is.

Jack Willis