### PR TITLE
Fix spacing on not-found message

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -167,7 +167,7 @@
       [:body
        (header-block title)
       [:div {:class "section examples"}
-       [:p [:h2 (str "We couldn't find those pronouns in our database."
+       [:p [:h2 (str "We couldn't find those pronouns in our database. "
                      "If you think we should have them, please reach out!")]]]
        (footer-block)]])))
 


### PR DESCRIPTION
Not familiar with hiccup, but I see similar spacing on https://github.com/witch-house/pronoun.is/blob/master/src/pronouns/pages.clj#L78 so figured I'd roll with it.