### PR TITLE
Put ring-devel back in main dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,11 +2,12 @@
   :description "Pronoun.is is a website for personal pronoun usage examples"
   :url "https://pronoun.is"
   :license "GNU Affero General Public License 3.0"
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [compojure "1.6.1"]
-                 [ring/ring-jetty-adapter "1.7.1"]
+  :dependencies [[compojure "1.6.1"]
                  [environ "1.1.0"]
-                 [hiccup "1.0.5"]]
+                 [hiccup "1.0.5"]
+                 [org.clojure/clojure "1.9.0"]
+                 [ring/ring-devel "1.7.1"]
+                 [ring/ring-jetty-adapter "1.7.1"]]
   :min-lein-version "2.0.0"
   :plugins [[environ/environ.lein "0.2.1"]
             [lein-ring "0.9.7"]]
@@ -14,6 +15,5 @@
   :uberjar-name "pronouns-standalone.jar"
   ;; FIXME morgan.astra <2018-11-14 Wed>
   ;; Is this production profile used for anything?
-  :profiles {:production {:env {:production true}}
-             :test {:dependencies [[ring/ring-devel "1.7.1"]]}}
+  :profiles {:production {:env {:production true}}}
   :ring {:handler pronouns.web/app})

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
   :dependencies [[compojure "1.6.1"]
                  [environ "1.1.0"]
                  [hiccup "1.0.5"]
+                 [lambdaisland/ring.middleware.logger "0.5.1"]
                  [org.clojure/clojure "1.9.0"]
                  [ring/ring-devel "1.7.1"]
                  [ring/ring-jetty-adapter "1.7.1"]]

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -21,9 +21,7 @@
             [clojure.string :as s]
             [clojure.java.io :as io]
             [ring.adapter.jetty :as jetty]
-            ;; FIXME morgan.astra <2018-11-14 Wed>
-            ;; make this logger work or use another one
-            ;; [ring.middleware.logger :as logger]
+            [ring.middleware.logger :as logger]
             [ring.middleware.stacktrace :as trace]
             [ring.middleware.params :as params]
             [ring.middleware.resource :refer [wrap-resource]]
@@ -79,9 +77,7 @@
       ;; (wrap-resource "images")
       wrap-content-type
       wrap-not-modified
-      ;; FIXME morgan.astra <2018-11-14 Wed>
-      ;; make this logger work or use another one
-      ;logger/wrap-with-logger
+      logger/wrap-with-logger
       wrap-error-page
       wrap-gnu-natalie-nguyen
       trace/wrap-stacktrace


### PR DESCRIPTION
It's needed in prod for the ring-stacktrace middleware