### PR TITLE
Support `:or` in path, in addition to parameter

### DIFF
--- a/test/pronouns/pages_test.clj
+++ b/test/pronouns/pages_test.clj
@@ -3,7 +3,7 @@
             [clojure.test :refer [deftest testing is are]]))
 
 (deftest prose-comma-list
-  (testing "prose-comma-list turns a list of strings into a prose list"
+  (testing "`prose-comma-list` turns a list of strings into a prose list"
     (are [v s] (= (pages/prose-comma-list v) s)
       ["foo" "bar" "baz" "bobble"] "foo, bar, baz, and bobble"
       ["foo" "bar" "baz"]          "foo, bar, and baz"
@@ -17,7 +17,7 @@
          pronouns)
     ["she/her"]           '(["she" "her" "her" "hers" "herself"])
     ["she" "they"]        '(["she" "her" "her" "hers" "herself"]
-                           ["they" "them" "their" "theirs" "themselves"])
+                            ["they" "them" "their" "theirs" "themselves"])
     ["she/her" "foo/bar"] '(["she" "her" "her" "hers" "herself"])
     ["foo/bar"]           '()
     ["a/b/c/d/e"]         '(("a" "b" "c" "d" "e"))))

--- a/test/pronouns/pages_test.clj
+++ b/test/pronouns/pages_test.clj
@@ -4,9 +4,20 @@
 
 (deftest prose-comma-list
   (testing "prose-comma-list turns a list of strings into a prose list"
-    (are [call result] (= call result)
-      (pages/prose-comma-list ["foo"]) "foo"
-      (pages/prose-comma-list ["foo" "bar"]) "foo and bar"
-      (pages/prose-comma-list ["foo" "bar" "baz"]) "foo, bar, and baz"
-      (pages/prose-comma-list ["foo" "bar" "baz" "bobble"]) "foo, bar, baz, and bobble"
-      (pages/prose-comma-list []) "")))
+    (are [v s] (= (pages/prose-comma-list v) s)
+      ["foo" "bar" "baz" "bobble"] "foo, bar, baz, and bobble"
+      ["foo" "bar" "baz"]          "foo, bar, and baz"
+      ["foo" "bar"]                "foo and bar"
+      ["foo"]                      "foo"
+      []                           "")))
+
+(deftest lookup-pronouns
+  (are [pronoun-strs pronouns]
+      (= (pages/lookup-pronouns pronoun-strs)
+         pronouns)
+    ["she/her"]           '(["she" "her" "her" "hers" "herself"])
+    ["she" "they"]        '(["she" "her" "her" "hers" "herself"]
+                           ["they" "them" "their" "theirs" "themselves"])
+    ["she/her" "foo/bar"] '(["she" "her" "her" "hers" "herself"])
+    ["foo/bar"]           '()
+    ["a/b/c/d/e"]         '(("a" "b" "c" "d" "e"))))


### PR DESCRIPTION
If someone writes a URL containing `or` as a path element (as opposed to `:or`), the `not-found` page will include a "did you mean" suggestion correcting it. This sets the precedent for the `not-found` page to suggest typo corrections as well, but actually implementing that will take some more design.

Includes additional test coverage!

s/o @lynn for initiating this

Fixes #69 
