### PR TITLE
Specify an UTF-8 Charset and use an html special character to avoid a malformed tag error in the footer

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -111,7 +111,7 @@
          (href "https://www.gnu.org/licenses/agpl.html" "AGPLv3")
          "! visit the project on "
          (href "https://github.com/witch-house/pronoun.is" "github")]
-     [:p "<3"]]))
+     [:p "&lt;3"]]))
 
 (defn footer-block []
   [:footer (usage-block) (contact-block)])
@@ -126,6 +126,7 @@
       [:head
        [:title title]
        [:meta {:name "viewport" :content "width=device-width"}]
+       [:meta {:charset "utf-8"}]
        [:meta {:name "description" :content (u/strip-markup examples)}]
        [:meta {:name "twitter:card" :content "summary"}]
        [:meta {:name "twitter:title" :content title}]
@@ -164,6 +165,7 @@
       [:head
        [:title title]
        [:meta {:name "viewport" :content "width=device-width"}]
+       [:meta {:charset "utf-8"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body
        (header-block title)
@@ -183,6 +185,7 @@
       [:head
        [:title title]
        [:meta {:name "viewport" :content "width=device-width"}]
+       [:meta {:charset "utf-8"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body
        (header-block title)
@@ -199,6 +202,7 @@
       [:head
        [:title title]
        [:meta {:name "viewport" :content "width=device-width"}]
+       [:meta {:charset "utf-8"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body
        (header-block title)


### PR DESCRIPTION
This pull request specifies an UTF-8 Charset on all pages. (This is most common and includes emoji support, if the project prefers plain ASCII let me know and I'll amend my PR) and uses an html special character in the footer to avoid a malformed tag error (we have an un-closed `<3` tag, this isn't intended to be a tag however some browsers may attempt to parse it and warn or throw an error, using the special character for `<` fixes this issue).

  - [x] PR message includes a link to the relevant issue(s) 💁‍♀️🖇️🧾
  - [x] Commit messages are well-formatted
  (please follow [this guide](https://chris.beams.io/posts/git-commit/)) 📝📐
  - [x] New features have test coverage 📋☑️☑️☑️
  - [x] The app boots and pronoun pages are served correctly 
  (try `lein ring server`) 👩‍💻🚀
