### PR TITLE
Added a few meta tags for the front page

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -158,11 +158,13 @@
 (defn front []
   (let [abbreviations (take 6 (u/abbreviate @pronouns-table))
         links (map make-link abbreviations)
-        title "Pronoun Island"]
+        title "Pronoun Island"
+        description "Pronoun.is is a website for personal pronoun usage examples."]
     (html
      [:html
       [:head
        [:title title]
+       [:meta {:name "description" :content description}]
        [:meta {:name "viewport" :content "width=device-width"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -165,6 +165,9 @@
       [:head
        [:title title]
        [:meta {:name "description" :content description}]
+       [:meta {:name "twitter:card" :content "summary"}]
+       [:meta {:name "twitter:title" :content title}]
+       [:meta {:name "twitter:description" :content description}]
        [:meta {:name "viewport" :content "width=device-width"}]
        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
       [:body


### PR DESCRIPTION
Metadata scrapers (for URL embeds) only return the title when referencing the front page. I added a few tags so that it would display on sites like Twitter.

If you'd like to, I can also make an image to be displayed.