### PR TITLE
Add ey/em/eir/eirs/eirself to pronouns.tab

### DIFF
--- a/resources/pronouns.tab
+++ b/resources/pronouns.tab
@@ -7,6 +7,7 @@ xey	xem	xyr	xyrs	xemself
 ae	aer	aer	aers	aerself
 e	em	eir	eirs	emself
 ey	em	eir	eirs	eirself
+ey	em	eir	eirs	emself
 fae	faer	faer	faers	faerself
 fey	fem	feir	feirs	feirself
 hu	hum	hus	hus	humself


### PR DESCRIPTION
Add https://pronoun.is/ey/em/eir/eirs/eirself to pronouns.tab:
* Link to the relevant issue: https://pronoun.is/ey/.../emself
* Compare to working example: https://pronoun.is/they/.../themself

Why these pronouns are relevant: 
1. I  want to be able to link to them without writing the full unwieldy URL out, just like I can with they/.../themself.
2. [Elverson (1975) pronouns](https://en.wikipedia.org/wiki/Spivak_pronoun): ey/em/eir/eirs/emself are a used by people. Note that words "ey" and "emself" are found in every one of the external links below (that combination is missing from the database, which has entries only for combinations e/.../emself and ey/.../eirself):
a. http://tib.cjcs.com/genderless-pronouns-ey-em-and-eir-2/
b. https://en.pronouns.page/ey
c. http://www.riotnrrdcomics.com/characters/

Should this pronoun set be included according to the [Philosophy on pronoun inclusion](/witch-house/pronoun.is/blob/master/README.md#philosophy-on-pronoun-inclusion)? Yes.

I understand ey/.../emself is similar to ey/.../eirself but emself is actually more popular ([Google Ngram Viewer](https://books.google.com/ngrams/graph?content=emself%2Ceirself&year_start=1800), [Google Trends](https://trends.google.com/trends/explore?date=all&q=emself,eirself)) so if ey/.../eirself is included, so should ey/.../emself be.