### PR TITLE
Rainbow Declensions!

### DIFF
--- a/resources/pronouns.css
+++ b/resources/pronouns.css
@@ -28,3 +28,48 @@ footer {
 
 .table {
 }
+
+/* Pronoun Badges and Colors */
+.pronouns { /* TODO: Perhaps add badge styling to pronouns. */ }
+
+/* Specific Pronouns */
+.pronouns.she.her.her.hers.herself { color: default }
+.pronouns.he.him.his.his.himself { color: default }
+.pronouns.they.them.their.theirs.themselves { color: default }
+.pronouns.ze.hir.hir.hirs.hirself { color: default }
+.pronouns.ze.zir.zir.zirs.zirself { color: default }
+.pronouns.xey.xem.xyr.xyrs.xemself { color: default }
+.pronouns.ae.aer.aer.aers.aerself { color: default }
+.pronouns.e.em.eir.eirs.emself { color: default }
+.pronouns.ey.em.eir.eirs.eirself { color: default }
+.pronouns.fae.faer.faer.faers.faerself { color: default }
+.pronouns.fey.fem.feir.feirs.feirself { color: default }
+.pronouns.hu.hum.hus.hus.humself { color: default }
+.pronouns.it.it.its.its.itself { color: default }
+.pronouns.jee.jem.jeir.jeirs.jemself { color: default }
+.pronouns.kit.kit.kits.kits.kitself { color: default }
+.pronouns.ne.nem.nir.nirs.nemself { color: default }
+.pronouns.peh.pehm.pehs.pehs.pehself { color: default }
+.pronouns.per.per.per.pers.perself { color: default }
+.pronouns.sie.hir.hir.hirs.hirself { color: default }
+.pronouns.se.sim.ser.sers.serself { color: default }
+.pronouns.shi.hir.hir.hirs.hirself { color: default }
+.pronouns.si.hyr.hyr.hyrs.hyrself { color: default }
+.pronouns.they.them.their.theirs.themself { color: default }
+.pronouns.thon.thon.thons.thons.thonself { color: default }
+.pronouns.ve.ver.vis.vis.verself { color: default }
+.pronouns.ve.vem.vir.virs.vemself { color: default }
+.pronouns.vi.ver.ver.vers.verself { color: default }
+.pronouns.vi.vim.vir.virs.vimself { color: default }
+.pronouns.vi.vim.vim.vims.vimself { color: default }
+.pronouns.xie.xer.xer.xers.xerself { color: default }
+.pronouns.xe.xem.xyr.xyrs.xemself { color: default }
+.pronouns.xey.xem.xeir.xeirs.xemself { color: default }
+.pronouns.yo.yo.yos.yos.yosself { color: default }
+.pronouns.ze.zem.zes.zes.zirself { color: default }
+.pronouns.ze.mer.zer.zers.zemself { color: default }
+.pronouns.zee.zed.zeta.zetas.zedself { color: default }
+.pronouns.zie.zir.zir.zirs.zirself { color: default }
+.pronouns.zie.zem.zes.zes.zirself { color: default }
+.pronouns.zie.hir.hir.hirs.hirself { color: default }
+.pronouns.zme.zmyr.zmyr.zmyrs.zmyrself { color: default }

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -37,8 +37,8 @@
 ;; FIXME morgan.astra <2018-11-14 Wed>
 ;; use a div for this instead of a plain bold tag
 (defn wrap-pronoun
-  [pronoun]
-  [:b pronoun])
+  [pronoun] ;; Replace tabs with a period and apostrophes with an empty string. - tacosontitan 3 SEP 2021
+  [:b {:class (str/replace (str/replace (str "." pronoun) "\t" ".") "'" "")} pronoun])
 
 (defn render-sentence [& content]
   [:p [:span.sentence content]])


### PR DESCRIPTION
  - [x] PR message includes a link to the relevant issue(s) 💁‍♀️🖇️🧾
  - [x] Commit messages are well-formatted
  (please follow [this guide](https://chris.beams.io/posts/git-commit/)) 📝📐
  - [ ] New features have test coverage 📋☑️☑️☑️
  - [ ] The app boots and pronoun pages are served correctly 
  (try `lein ring server`) 👩‍💻🚀

Fixes Issue[ #95 Rainbow Declensions!](https://github.com/witch-house/pronoun.is/issues/95)
---
### Important Note
I'm unable to verify the last two bullet points as I have to get my laptop repaired and haven't had time. However, the string replacement is straight forward and can be verified using [this online compiler](https://www.tutorialspoint.com/execute_clojure_online.php) and the following snippet:

```
(ns tst.demo.core
  (:require
    [clojure.string :as str]
  ))

 (println (str/replace (str/replace (str "." "she	her	her	her's	herself") "\t" ".") "'" ""))
```
<sub>***Note**: The table contains a pronoun set with an apostrophe, so I accounted for that in the above snippet.*</sub>

### How it Works
This feature works by taking the pronoun and replacing tab characters (`\t` in the above snippet) with a period `.`. Then, to make things safe when pronouns contain apostrophes (such as with `peh	pehm	peh's	peh's	pehself`) an additional replacement is made to replace the apostrophe `'` with an empty string `""`.

The result is assigned as the class to the `b` element.

### Adding New Pronouns
When adding new pronouns, not only will we have to ensure that tabs are used in the table, but the appropriate CSS classes should be added, for example, adding the she/her set:

    ;; Table
    she	her	her	hers	herself

    ;; prounouns.css
    .pronouns.she.her.her.hers.herself { color: default; }