### PR TITLE
Add a block that shows the computed pronouns

### DIFF
--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -89,6 +89,18 @@
          (possessive-pronoun-example possessive-pronoun)
          (reflexive-example subject reflexive)]]))
 
+(defn assumed-block 
+  [subject object possessive-determiner possessive-pronoun reflexive]
+  (let [sub-obj (s/join "/" [subject object])
+        header-str (str "We have assumed a full usage of:")]
+    [:div {:class "section assumed"}
+     [:p header-str]
+     [:tt (str "https://pronoun.is/" (s/join "/" [subject
+          object
+          possessive-determiner
+          possessive-pronoun
+          reflexive]))]]))
+
 (defn usage-block []
   [:div {:class "section usage"}
    [:p "Full usage: "
@@ -120,7 +132,8 @@
   [pronoun-declensions]
   (let [sub-objs (map #(s/join "/" (take 2 %)) pronoun-declensions)
         title (str "Pronoun Island: " (prose-comma-list sub-objs) " examples")
-        examples (map #(apply examples-block %) pronoun-declensions)]
+        examples (map #(apply examples-block %) pronoun-declensions)
+        assumed (map #(apply assumed-block %) pronoun-declensions)]
     (html
      [:html
       [:head
@@ -135,6 +148,7 @@
       [:body
        (header-block title)
        examples
+       assumed
        (footer-block)]])))
 
 (defn table-lookup* [pronouns-string]


### PR DESCRIPTION
* The database assumes a set of pronouns based on what you type in.
  This prints out all of the assumed pronouns after the examples.

I'm not totally sure if there's a way to test this, but it uses all of the same data as examples, so I think assuming their existence isn't a problem.

*Thanks for contributing! Please check the following things before submitting your PR :)*

- [ ] PR message includes a link to the relevant issue(s) 💁‍♀️🖇️🧾
- [X] Commit messages are well-formatted
  (please follow [this guide](https://chris.beams.io/posts/git-commit/)) 📝📐
- [ ] New features have test coverage 📋☑️☑️☑️
- [X] The app boots and pronoun pages are served correctly 
  (try `lein ring server`) 👩‍💻🚀
