### PR TITLE
Better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,21 @@
 **Table of Contents**
 
 - [pronoun.is](#pronounis)
-    - [For users](#for-users)
-    - [For developers](#for-developers)
-        - [The database](#the-database)
-        - [The code](#the-code)
-        - [Tests](#tests)
-        - [Running the app in a dev environment](#running-the-app-in-a-dev-environment)
-        - [The git repo](#the-git-repo)
-    - [Philosophy on pronoun inclusion](#philosophy-on-pronoun-inclusion)
-    - [FAQ](#faq)
-        - [Can we translate pronoun.is into another language?](#can-we-translate-pronounis-into-another-language)
-        - [Can we change the example sentences?](#can-we-change-the-example-sentences)
-        - [Can we add pronunciation guides?](#can-we-add-pronunciation-guides)
-        - [Can we add pluralization support (i.e. themself vs themselves)](#can-we-add-pluralization-support-ie-themself-vs-themselves)
-    - [License](#license)
+  - [For users](#for-users)
+  - [For system admins and self-hosters](#for-system-admins-and-self-hosters)
+  - [For developers](#for-developers)
+    - [The database](#the-database)
+    - [The code](#the-code)
+    - [Tests](#tests)
+    - [Running the app in a dev environment](#running-the-app-in-a-dev-environment)
+    - [The git repo](#the-git-repo)
+  - [Philosophy on pronoun inclusion](#philosophy-on-pronoun-inclusion)
+  - [FAQ](#faq)
+    - [Can we translate pronoun.is into another language?](#can-we-translate-pronounis-into-another-language)
+    - [Can we change the example sentences?](#can-we-change-the-example-sentences)
+    - [Can we add pronunciation guides?](#can-we-add-pronunciation-guides)
+    - [Can we add pluralization support (i.e. themself vs themselves)](#can-we-add-pluralization-support-ie-themself-vs-themselves)
+  - [License](#license)
 
 <!-- markdown-toc end -->
 
@@ -32,6 +33,9 @@ url path. For example, https://pronoun.is/ze/zir/zir/zirs/zirself
 That's pretty unwieldy! Fortunately you can also give it only the
 first pronoun or two: https://pronoun.is/she/her or https://pronoun.is/they
 
+You can also specific multiple pronoun sets with `?or=`; for example:
+https://pronoun.is/she?or=they
+
 Automatically filling in the rest from only one or two forms only
 works for pronouns in the [database][pronoun-database]. If the
 pronouns you or a friend uses aren't supported, please let us know and
@@ -43,7 +47,7 @@ pull request (see the next section for details)
 
 There are several ways to run pronoun.is yourself:
 
-* *Recommended:* Use docker or podman: e.g. `podman build -t witch-house/pronouns .`
+* *Recommended:* Use podman or docker: e.g. `podman build -t witch-house/pronouns .`
 * This repository has a `Procfile` for use with Heroku
 * Finally, you can create an uberjar (`lein uberjar`), set the `PORT`
  environment variable, and run it using Java: `java -jar
@@ -94,14 +98,17 @@ in that namespace should live!
 
 ### Tests
 
-Run the suite with `lein test`
+Run the suite with `lein test :all`.
 
-Test coverage is not great but getting better. Please run the tests and
+You can also do `lein test :unit` to skip e2e tests, however the e2e tests
+only add about 4 seconds of run time and can be quite informative.
+
+Test coverage is not 100% but getting pretty good. Please run the tests and
 confirm that everything passes before merging changes, and please include
 tests with any new logic you introduce in a PR!
 
-Goals for the future include setting up automated CI to run the tests for
-us on every PR branch
+You can use `lein preflight` to run everything the CI pipeline does in one
+go on the CLI. Do this before opening a PR.
 
 ### Running the app in a dev environment
 
@@ -119,10 +126,7 @@ and requires an app restart to reload.
 
 ### The git repo
 
-For most of this project's history we had separate `main` and `develop`
-branches but that's proven to be more trouble than it's worth. Going
-forward we'll be doing all development in feature branches off of `main`,
-and PRs should be issued against `main`.
+All PRs should be issued against `main`.
 
 Please follow [this guide](https://chris.beams.io/posts/git-commit/)
 for writing good commit messages :)
@@ -189,4 +193,3 @@ GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>
-

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
   :min-lein-version "2.4.0"
   :plugins [[lein-environ "1.2.0"]
             [lein-ring "0.12.6"]
-            [lein-ancient "0.7.0"]
+            [lein-ancient "1.0.0-RC3"]
             [jonase/eastwood "1.4.3"]]
   :uberjar-name "pronouns-standalone.jar"
   :main pronouns.web

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject witch-house/pronouns "1.12.0-SNAPSHOT"
+(defproject witch-house/pronouns "1.13.0-SNAPSHOT"
   :description "Pronoun.is is a website for personal pronoun usage examples"
   :url "https://pronoun.is"
   :license "GNU Affero General Public License 3.0"
@@ -11,6 +11,7 @@
                  [ring-logger "1.1.1"]
                  [ring/ring-devel "1.15.4"]
                  [ring/ring-jetty-adapter "1.15.4"]
+                 [manifold "0.5.0"]
                  [compojure "1.7.2"]]
   :min-lein-version "2.4.0"
   :plugins [[lein-environ "1.2.0"]

--- a/project.clj
+++ b/project.clj
@@ -28,4 +28,5 @@
   :test-selectors {:default (complement :e2e)
                    :unit :unit
                    :e2e :e2e
-                   :all identity})
+                   :all identity}
+  :aliases {"preflight" ["do" "check," "ancient," "eastwood," ["test" ":all"],"uberjar"]})

--- a/project.clj
+++ b/project.clj
@@ -30,4 +30,4 @@
                    :unit :unit
                    :e2e :e2e
                    :all identity}
-  :aliases {"preflight" ["do" "check," "ancient," "eastwood," ["test" ":all"],"uberjar"]})
+  :aliases {"preflight" ["do" "check," "eastwood," ["test" ":all"],"uberjar," "ancient"]})

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -201,8 +201,8 @@
         (footer-block)]))))
 
 (defn not-found [path]
-  (let [title "Pronoun Island: English Language Examples"
-        or-re #"/[oO][rR]/"]
+  (let [title "Pronoun Island - Not Found :("
+        or-re #"/or/"]
     (str
      (h/html
       [:html
@@ -219,15 +219,32 @@
          (when (re-find or-re path)
            (let [alts (s/split path or-re)
                  new-path (str "/" (s/join "/:OR/" alts))]
-              [:div
-               "Did you mean: "
-               (href new-path
-                     (str "pronoun.is"
-                          new-path))]))]
-         (footer-block)]]))))
+             [:div
+              "Did you mean: "
+              (href new-path
+                    (str "pronoun.is"
+                         new-path))]))]
+        (footer-block)]]))))
+
+(defn error [_req]
+  (let [title "Pronoun Island - Error :("]
+    (str
+     (h/html
+      [:html
+       [:head
+        [:title title]
+        [:meta {:name "viewport" :content "width=device-width"}]
+        [:meta {:charset "utf-8"}]
+        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+       [:body
+        (header-block title)
+        [:div {:class "section examples"}
+         [:p [:h2 "Something went wrong :("]
+          "Go back to the " (href "/" "front page")]]
+        (footer-block)]]))))
 
 (defn pronouns [params]
-  (let [path (params :*)
+  (let [path (s/lower-case (params :*))
         param-alts (u/vec-coerce (or (params "or") []))
         path-alts (s/split path #"/:[oO][rR]/")
         pronouns (lookup-pronouns (concat path-alts param-alts))]

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -165,6 +165,7 @@
       [:meta {:name "twitter:card" :content "summary"}]
       [:meta {:name "twitter:title" :content title}]
       [:meta {:name "twitter:description" :content description}]
+
       [:meta {:name "viewport" :content "width=device-width"}]
       [:meta {:charset "utf-8"}]
       [:link {:rel "stylesheet" :href "/pronouns.css"}]]
@@ -174,16 +175,22 @@
        [:p "pronoun.is is a website for personal pronoun usage examples"]
        [:p "here are some pronouns the site knows about:"]
        [:ul links]
-       [:p [:small (href "all-pronouns" "see all pronouns in the database")]]]]
-     (footer-block)]))
+       [:p [:small (href "all-pronouns" "see all pronouns in the database")]]]
+      (footer-block)]]))
 
 (defn all-pronouns* []
   (let [abbreviations (u/abbreviate @pronouns-table)
         links (map make-link abbreviations)
-        title "Pronoun Island"]
+        title "Pronoun Island"
+        description "Pronoun.is is a website for personal pronoun usage examples."]
     [:html
      [:head
       [:title title]
+      [:meta {:name "description" :content description}]
+      [:meta {:name "twitter:card" :content "summary"}]
+      [:meta {:name "twitter:title" :content title}]
+      [:meta {:name "twitter:description" :content description}]
+
       [:meta {:name "viewport" :content "width=device-width"}]
       [:meta {:charset "utf-8"}]
       [:link {:rel "stylesheet" :href "/pronouns.css"}]]
@@ -191,8 +198,8 @@
       (header-block title)
       [:div {:class "section table"}
        [:p "All pronouns the site knows about:"]
-       [:ul links]]]
-     (footer-block)]))
+       [:ul links]]
+      (footer-block)]]))
 
 (defn not-found* [path]
   (let [title "Pronoun Island - Not Found :("
@@ -210,7 +217,7 @@
         "If you think we should have them, please reach out!"]
        (when (re-find or-re path)
          (let [alts (s/split path or-re)
-               new-path (str "/" (s/join "/:OR/" alts))]
+               new-path (str "/" (s/join "/:or/" alts))]
            [:div
             "Did you mean: "
             (href new-path

--- a/src/pronouns/pages.clj
+++ b/src/pronouns/pages.clj
@@ -119,22 +119,20 @@
   (let [sub-objs (map #(s/join "/" (take 2 %)) pronoun-declensions)
         title (str "Pronoun Island: " (prose-comma-list sub-objs) " examples")
         examples (map #(apply examples-block %) pronoun-declensions)]
-    (str
-     (h/html
-      [:html
-       [:head
-        [:title title]
-        [:meta {:name "viewport" :content "width=device-width"}]
-        [:meta {:charset "utf-8"}]
-        [:meta {:name "description" :content (u/strip-markup examples)}]
-        [:meta {:name "twitter:card" :content "summary"}]
-        [:meta {:name "twitter:title" :content title}]
-        [:meta {:name "twitter:description" :content (u/strip-markup examples)}]
-        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-       [:body
-        (header-block title)
-        examples
-        (footer-block)]]))))
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:meta {:charset "utf-8"}]
+      [:meta {:name "description" :content (u/strip-markup examples)}]
+      [:meta {:name "twitter:card" :content "summary"}]
+      [:meta {:name "twitter:title" :content title}]
+      [:meta {:name "twitter:description" :content (u/strip-markup examples)}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (header-block title)
+      examples
+      (footer-block)]]))
 
 (defn table-lookup* [pronouns-string]
   (let [inputs (s/split pronouns-string #"/")
@@ -155,99 +153,99 @@
         label path]
     [:li (href link label)]))
 
-(defn front []
+(defn front* []
   (let [abbreviations (take 6 (u/abbreviate @pronouns-table))
         links (map make-link abbreviations)
         title "Pronoun Island"
         description "Pronoun.is is a website for personal pronoun usage examples."]
-    (str
-     (h/html
-      [:html
-       [:head
-        [:title title]
-        [:meta {:name "description" :content description}]
-        [:meta {:name "twitter:card" :content "summary"}]
-        [:meta {:name "twitter:title" :content title}]
-        [:meta {:name "twitter:description" :content description}]
-        [:meta {:name "viewport" :content "width=device-width"}]
-        [:meta {:charset "utf-8"}]
-        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-       [:body
-        (header-block title)
-        [:div {:class "section table"}
-         [:p "pronoun.is is a website for personal pronoun usage examples"]
-         [:p "here are some pronouns the site knows about:"]
-         [:ul links]
-         [:p [:small (href "all-pronouns" "see all pronouns in the database")]]]]
-        (footer-block)]))))
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "description" :content description}]
+      [:meta {:name "twitter:card" :content "summary"}]
+      [:meta {:name "twitter:title" :content title}]
+      [:meta {:name "twitter:description" :content description}]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:meta {:charset "utf-8"}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (header-block title)
+      [:div {:class "section table"}
+       [:p "pronoun.is is a website for personal pronoun usage examples"]
+       [:p "here are some pronouns the site knows about:"]
+       [:ul links]
+       [:p [:small (href "all-pronouns" "see all pronouns in the database")]]]]
+     (footer-block)]))
 
-(defn all-pronouns []
+(defn all-pronouns* []
   (let [abbreviations (u/abbreviate @pronouns-table)
         links (map make-link abbreviations)
         title "Pronoun Island"]
-    (str
-     (h/html
-      [:html
-       [:head
-        [:title title]
-        [:meta {:name "viewport" :content "width=device-width"}]
-        [:meta {:charset "utf-8"}]
-        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-       [:body
-        (header-block title)
-        [:div {:class "section table"}
-         [:p "All pronouns the site knows about:"]
-         [:ul links]]]
-        (footer-block)]))))
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:meta {:charset "utf-8"}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (header-block title)
+      [:div {:class "section table"}
+       [:p "All pronouns the site knows about:"]
+       [:ul links]]]
+     (footer-block)]))
 
-(defn not-found [path]
+(defn not-found* [path]
   (let [title "Pronoun Island - Not Found :("
         or-re #"/or/"]
-    (str
-     (h/html
-      [:html
-       [:head
-        [:title title]
-        [:meta {:name "viewport" :content "width=device-width"}]
-        [:meta {:charset "utf-8"}]
-        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-       [:body
-        (header-block title)
-        [:div {:class "section examples"}
-         [:p [:h2 "We couldn't find those pronouns in our database :("]
-          "If you think we should have them, please reach out!"]
-         (when (re-find or-re path)
-           (let [alts (s/split path or-re)
-                 new-path (str "/" (s/join "/:OR/" alts))]
-             [:div
-              "Did you mean: "
-              (href new-path
-                    (str "pronoun.is"
-                         new-path))]))]
-        (footer-block)]]))))
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:meta {:charset "utf-8"}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (header-block title)
+      [:div {:class "section examples"}
+       [:p [:h2 "We couldn't find those pronouns in our database :("]
+        "If you think we should have them, please reach out!"]
+       (when (re-find or-re path)
+         (let [alts (s/split path or-re)
+               new-path (str "/" (s/join "/:OR/" alts))]
+           [:div
+            "Did you mean: "
+            (href new-path
+                  (str "pronoun.is"
+                       new-path))]))]
+      (footer-block)]]))
 
-(defn error [_req]
+(defn error* [_req]
   (let [title "Pronoun Island - Error :("]
-    (str
-     (h/html
-      [:html
-       [:head
-        [:title title]
-        [:meta {:name "viewport" :content "width=device-width"}]
-        [:meta {:charset "utf-8"}]
-        [:link {:rel "stylesheet" :href "/pronouns.css"}]]
-       [:body
-        (header-block title)
-        [:div {:class "section examples"}
-         [:p [:h2 "Something went wrong :("]
-          "Go back to the " (href "/" "front page")]]
-        (footer-block)]]))))
+    [:html
+     [:head
+      [:title title]
+      [:meta {:name "viewport" :content "width=device-width"}]
+      [:meta {:charset "utf-8"}]
+      [:link {:rel "stylesheet" :href "/pronouns.css"}]]
+     [:body
+      (header-block title)
+      [:div {:class "section examples"}
+       [:p [:h2 "Something went wrong :("]
+        "Go back to the " (href "/" "front page")]]
+      (footer-block)]]))
+
+(defn render [data]
+  (-> data h/html str))
+
+(def front (comp render front*))
+(def all-pronouns (comp render all-pronouns*))
+(def not-found (comp render not-found*))
+(def error (comp render error*))
 
 (defn pronouns [params]
   (let [path (s/lower-case (params :*))
         param-alts (u/vec-coerce (or (params "or") []))
         path-alts (s/split path #"/:[oO][rR]/")
         pronouns (lookup-pronouns (concat path-alts param-alts))]
-    (if (seq pronouns)
-      (format-pronoun-examples pronouns)
-      (not-found path))))
+    (render (if (seq pronouns)
+              (format-pronoun-examples pronouns)
+              (not-found path)))))

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -70,6 +70,12 @@
     (when-let [resp (handler req)]
       (assoc-in resp [:headers "X-Clacks-Overhead"] "GNU Natalie Nguyen"))))
 
+(defn wrap-slash-normalization [handler]
+  (fn [req]
+    (let [uri (:uri req)
+          normalized (s/replace uri #"/{2,}" "/")]
+      (handler (assoc req :uri normalized)))))
+
 (defn wrap-error-page [handler]
   (fn [req]
     (try (handler req)
@@ -81,6 +87,7 @@
 
 (def base-middleware
   #(-> %
+       wrap-slash-normalization
        wrap-content-type
        wrap-not-modified
        logger/wrap-with-logger
@@ -101,8 +108,32 @@
              "Example: PORT=3000 lein run")
   (System/exit 1))
 
+(defn uri-compliance-legacy
+  "Jetty configurator function to set UriCompliance to LEGACY.
+
+  This configuration allows URIs containing multiple subsequent slashes
+  to pass through to Ring, where we handle them as a single slash.
+
+  For context see:
+  https://jetty.org/docs/jetty/12.1/programming-guide/server/compliance.html#uri
+  and this issue on the Jetty project:
+  https://github.com/jetty/jetty.project/issues/11298 "
+  [^org.eclipse.jetty.server.Server server]
+  (doseq [^org.eclipse.jetty.server.Connector
+          connector (.getConnectors server)
+
+          ^org.eclipse.jetty.server.HttpConnectionFactory
+          factory (.getConnectionFactories connector)
+
+          :when (instance? org.eclipse.jetty.server.HttpConnectionFactory factory)
+
+          :let [^org.eclipse.jetty.server.HttpConfiguration
+                conf (.getHttpConfiguration factory)]]
+    (.setUriCompliance conf org.eclipse.jetty.http.UriCompliance/LEGACY)))
+
 (defn -main []
   (if-let [port (:port env)]
     (jetty/run-jetty prod-app
-                     {:port (Integer/parseInt port)})
+                     {:port (Integer/parseInt port)
+                      :configurator uri-compliance-legacy})
     (no-port)))

--- a/src/pronouns/web.clj
+++ b/src/pronouns/web.clj
@@ -26,32 +26,44 @@
             [ring.middleware.not-modified :refer [wrap-not-modified]]
             [ring.logger :as logger]
             [environ.core :refer [env]]
-            [pronouns.pages :as pages])
+            [pronouns.pages :as pages]
+            [clojure.string :as s])
   (:gen-class))
 
 (defroutes app-routes
   (GET "/" []
-       {:status 200
-        :headers {"Content-Type" "text/html"}
-        :body (pages/front)})
+    {:status 200
+     :headers {"Content-Type" "text/html"}
+     :body (pages/front)})
 
   (GET "/all-pronouns" []
-       {:status 200
-        :headers {"Content-Type" "text/html"}
-        :body (pages/all-pronouns)})
+    {:status 200
+     :headers {"Content-Type" "text/html"}
+     :body (pages/all-pronouns)})
 
   (GET "/pronouns.css" []
-     {:status 200
+    {:status 200
      :headers {"Content-Type" "text/css"}
      :body (slurp (io/resource "pronouns.css"))})
 
-  (GET "/*" {params :params}
-       {:status 200
-        :headers {"Content-Type" "text/html"}
-        :body (pages/pronouns params)})
+  (GET "/coffee" []
+    {:status 418
+     :headers {"Content-Type" "text/html"}
+     :body "<strong>Sorry, this device cannot brew coffee</strong>"})
 
-  (ANY "*" []
-       (route/not-found (slurp (io/resource "404.html")))))
+  (ANY "/DEBUG-FORCE-500" []
+    (throw (Exception. "oh no a DEBUG-FORCE-500 error occurred!")))
+
+  (GET "/*" {params :params}
+    {:status 200
+     :headers {"Content-Type" "text/html"}
+     :body (pages/pronouns params)})
+
+  (ANY "*" {params :params}
+    (-> params
+        s/lower-case
+        pages/not-found
+        route/not-found)))
 
 (defn wrap-gnu-natalie-nguyen [handler]
   (fn [req]
@@ -65,7 +77,7 @@
            (log/error e)
            {:status 500
             :headers {"Content-Type" "text/html"}
-            :body (slurp (io/resource "500.html"))}))))
+            :body (pages/error req)}))))
 
 (def base-middleware
   #(-> %

--- a/test/pronouns/e2e_test.clj
+++ b/test/pronouns/e2e_test.clj
@@ -2,9 +2,11 @@
   (:require [clojure.test :refer [deftest testing is]]
             [clj-http.lite.client :as client]
             [clojure.tools.logging :as log]
+            [clojure.string :as string]
             [clojure.java.shell :refer [sh]]
             [clojure.java.process :as p]
-            [clojure.java.io :as io]))
+            [clojure.java.io :as io]
+            [manifold.stream :as stream]))
 
 (defn tcp-bound? [port]
   (zero? (:exit (sh "fuser" (str port "/tcp")))))
@@ -15,21 +17,46 @@
       port
       (recur (+ 1024 (rand-int 8900))))))
 
-(defn wait-for-server [timeout-ms port sproc]
+(defn process->log-stream [process]
+  (let [log-stream (stream/stream)]
+    (future
+      (try
+        (with-open [log-lines (-> process p/stderr io/reader line-seq)]
+          (loop [lines log-lines]
+            (when-let [line (first lines)]
+              (stream/put! log-stream line)
+              (recur (rest lines)))))
+        (finally (stream/close! log-stream))))
+    log-stream))
+
+(defn read-logs-and-kill [process]
+  (let [log-stream (process->log-stream process)
+        log-lines (atom [])]
+    (future (loop []
+              (when-let [line @(stream/take! log-stream)]
+                (swap! log-lines conj line)
+                (recur))))
+
+    (Thread/sleep 100) ;; Let the future reading the stream catch up
+    (.destroy process)
+    (stream/close! log-stream)
+    (Thread/sleep 100) ;; Let the process actually die
+
+    (string/join "\n" @log-lines)))
+
+(defn wait-for-server [timeout-ms port server-process]
   (let [start-time (System/currentTimeMillis)
         exp-time (+ timeout-ms start-time)]
 
     (log/info "Waiting for server to start on" port start-time exp-time)
     (loop []
       (when (> (System/currentTimeMillis) exp-time)
-        (with-open [r (-> sproc p/stderr io/reader)]
-          ;; We assume there will always be 4 lines to take and that's enough
-          ;; to hint at the issue. It would be better if we could read
-          ;; the whole log. Why can't we? (.destroy sproc) disappears the
-          ;; stderr and stdout streams
-          (let [log-lines (take 4 (line-seq r))]
-            (log/warn log-lines)
-            (throw (ex-info "Server startup timeout" {})))))
+        (log/warn "Server not up after" timeout-ms)
+        (log/warn "*** server-process logs below ***" timeout-ms)
+        (let [log-lines (read-logs-and-kill server-process)]
+          (log/warn log-lines)
+          (log/warn "*** server-process logs above ***")
+          (throw (ex-info "Server startup timeout" {}))))
       (Thread/sleep 500)
       (if (tcp-bound? port)
         (do (log/info "Server process took"
@@ -43,33 +70,79 @@
                   "CLASSPATH" ""}}
            "lein" "run"))
 
+(defn get-response [port path]
+  (client/get (str "http://localhost:" port path)
+              {:socket-timeout 5000
+               :conn-timeout 5000
+               :throw-exceptions false}))
+
+(defn assert-status-and-body [port test-cases]
+  (loop [test-cases test-cases]
+    (when-let [case (first test-cases)]
+      (let [response (get-response port (:path case))]
+        (testing (str "Response for " (:label case))
+          (is (= (:status case) (:status response)))
+          (is (re-find (:body-re case) (:body response)))))
+      (recur (rest test-cases)))))
+
+(defn assert-logs [final-logs test-cases]
+  (loop [test-cases test-cases]
+    (when-let [case (first test-cases)]
+      (when (:log-re case)
+        (testing (str "Log matches for " (:label case))
+          (is (re-find (:log-re case) final-logs))))
+      (recur (rest test-cases)))))
+
+(def e2e-server-test-cases
+  [{:label "Front page"
+    :path "/"
+    :status 200
+    :body-re #"<a href=\"all-pronouns\">"
+    :log-re #":request-method :get, :uri \"/\""}
+
+   {:label "ze/hir pronouns page"
+    :path "/ze/hir"
+    :status 200
+    :body-re #"ze/hir"}
+
+   {:label "they/.../themselves pronouns page"
+    :path "/they/.../themselves"
+    :status 200
+    :body-re #"they/them"}
+
+   {:label "Teapot"
+    :path "/coffee"
+    :status 418
+    :body-re #"cannot brew coffee"}
+
+   {:label "Not found page"
+    :path "/asdf/foo/bar"
+    :status 200
+    :body-re #"Not Found"}
+
+   {:label "Error page"
+    :path "/DEBUG-FORCE-500"
+    :status 500
+    :body-re #"Something went wrong"
+    :log-re #"DEBUG-FORCE-500 error occurred!"}])
+
 (deftest ^:e2e e2e-server-test
   (let [maxwait 120000
         port (find-open-port)
-        sproc (start-server port)]
+        server-process (start-server port)]
 
-    (wait-for-server maxwait port sproc)
+    (wait-for-server maxwait port server-process)
 
-    (testing "Boot server in child process and get front page")
-    (let [response (client/get (str "http://localhost:" port)
-                               {:throw-exceptions false})]
+    (testing "Boot server in child process, get page responses"
+      (assert-status-and-body port e2e-server-test-cases))
 
-      (testing "Response"
-        (is (= 200 (:status response)))
-        (is (re-find #"<a href=\"all-pronouns\">" (:body response))))
+    (testing "Server logs"
+      (let [final-log (read-logs-and-kill server-process)]
 
-      (testing "Server logs")
-      (let [final-log (future
-                        (with-open [r (-> sproc p/stderr io/reader)]
-                          (slurp r)))]
+        (log/debug "*** Subprocess log follows ***\n" final-log)
+        (assert-logs final-log e2e-server-test-cases)
 
-        ;;NOTE: You may ask why not simply `(.destroy sproc)`?
-        ;; The issue is that this prevents the io/reader from reading
-        ;; the stderr stream for some reason, so we would lose the
-        ;; server process's logs.
-        (sh "fuser" "-k" (str port "/tcp"))
-        (log/info "*** Subprocess log follows ***\n" @final-log)
-        (is (re-find #":request-method :get, :uri \"/\"" @final-log))
-        (is (not (re-find #"ERROR" @final-log))))))
+          ;; Nothing should ever crash the server
+        (is (not (re-find #"FATAL" final-log))))))
 
   (shutdown-agents))

--- a/test/pronouns/e2e_test.clj
+++ b/test/pronouns/e2e_test.clj
@@ -40,7 +40,9 @@
     (Thread/sleep 100) ;; Let the future reading the stream catch up
     (.destroy process)
     (stream/close! log-stream)
-    (Thread/sleep 100) ;; Let the process actually die
+
+    (let [exit @(p/exit-ref process)] ;; Wait for the process to die
+      (log/debug "Exit code: " exit))
 
     (string/join "\n" @log-lines)))
 

--- a/test/pronouns/e2e_test.clj
+++ b/test/pronouns/e2e_test.clj
@@ -100,6 +100,12 @@
     :body-re #"<a href=\"all-pronouns\">"
     :log-re #":request-method :get, :uri \"/\""}
 
+   {:label "Error page"
+    :path "/DEBUG-FORCE-500"
+    :status 500
+    :body-re #"Something went wrong"
+    :log-re #"DEBUG-FORCE-500 error occurred!"}
+
    {:label "ze/hir pronouns page"
     :path "/ze/hir"
     :status 200
@@ -120,11 +126,30 @@
     :status 200
     :body-re #"Not Found"}
 
-   {:label "Error page"
-    :path "/DEBUG-FORCE-500"
-    :status 500
-    :body-re #"Something went wrong"
-    :log-re #"DEBUG-FORCE-500 error occurred!"}])
+   {:label "Unknown URL parameter"
+    :path "/they?foo=bar"
+    :status 200
+    :body-re #"they/them"}
+
+   {:label "Pronoun with parameter alternate"
+    :path "/they?or=she"
+    :status 200
+    :body-re #"they.*she"}
+
+   {:label "Pronoun with path alternate"
+    :path "/they/:or/she"
+    :status 200
+    :body-re #"they.*she"}
+
+   {:label "Pronoun with two alternates"
+    :path "/they?or=she&or=ze"
+    :status 200
+    :body-re #"they.*she.*ze"}
+
+   {:label "Non-database pronoun with 5 path segments"
+    :path "/a/b/c/d/e"
+    :status 200
+    :body-re #"a/b examples"}])
 
 (deftest ^:e2e e2e-server-test
   (let [maxwait 120000

--- a/test/pronouns/e2e_test.clj
+++ b/test/pronouns/e2e_test.clj
@@ -17,19 +17,19 @@
       port
       (recur (+ 1024 (rand-int 8900))))))
 
-(defn process->log-stream [process]
+(defn process->log-stream [^java.lang.Process process]
   (let [log-stream (stream/stream)]
     (future
       (try
-        (with-open [log-lines (-> process p/stderr io/reader line-seq)]
-          (loop [lines log-lines]
+        (with-open [log-reader (-> process p/stderr io/reader)]
+          (loop [lines (line-seq log-reader)]
             (when-let [line (first lines)]
               (stream/put! log-stream line)
               (recur (rest lines)))))
         (finally (stream/close! log-stream))))
     log-stream))
 
-(defn read-logs-and-kill [process]
+(defn read-logs-and-kill [^java.lang.Process process]
   (let [log-stream (process->log-stream process)
         log-lines (atom [])]
     (future (loop []

--- a/test/pronouns/e2e_test.clj
+++ b/test/pronouns/e2e_test.clj
@@ -149,7 +149,12 @@
    {:label "Non-database pronoun with 5 path segments"
     :path "/a/b/c/d/e"
     :status 200
-    :body-re #"a/b examples"}])
+    :body-re #"a/b examples"}
+
+   {:label "Multiple slashes"
+    :path "///"
+    :status 200
+    :body-re #"<a href=\"all-pronouns\">"}])
 
 (deftest ^:e2e e2e-server-test
   (let [maxwait 120000

--- a/test/pronouns/pages_test.clj
+++ b/test/pronouns/pages_test.clj
@@ -25,12 +25,16 @@
     ["a/b/c/d/e"]         '(("a" "b" "c" "d" "e"))))
 
 ;; Tests for page construction
-(defn is-element? [tag form]
+(defn is-element?
+  "Is this <form> the element described by <tag>?"
+  [tag form]
   (when (and (vector? form)
              (= (first form) tag))
     form))
 
-(defn find-element-by-tag [tag form]
+(defn find-element-by-tag
+  "Return the seq of children of <form> that match <tag>"
+  [tag form]
   (walk/walk (partial is-element? tag)
              (partial remove nil?)
              form))
@@ -56,6 +60,11 @@
     body))
 
 (defn assert-element-values
+  "Generate test assertion that a given value is found at a given path
+  within the document tree.
+
+  FIXME: The argument ordering is a historical accident of the
+  implementation and makes very little sense."
   ([v path form key-fn]
    (testing (str "Assert element values: " v path))
    (is (= v
@@ -67,7 +76,10 @@
 (defn assert-has-head-block [result title]
   (testing (str title " has head block")
     (assert-element-values title [:head :title] result second)
-    (assert-element-values "/pronouns.css" [:head :link [:rel "stylesheet"]] result :href)
+    (assert-element-values "/pronouns.css"
+                           [:head :link [:rel "stylesheet"]]
+                           result
+                           :href)
     (assert-element-values "width=device-width"
                            [:head :meta [:name "viewport"]]
                            result
@@ -78,7 +90,6 @@
     (let [anchors (find-element-by-path [:body :footer :div :p :a]
                                         result)
           labels (into #{} (filter string? anchors))]
-      ;; (println title labels)
       (is (labels "@morganastra"))
       (is (labels "pronoun.is/she"))
       (is (labels "AGPLv3"))
@@ -86,7 +97,7 @@
 
 (defn assert-twitter-card
   ([result title description]
-   (testing (str title " has twitter meta block")
+   (testing (str title " has twitter card meta block")
      (assert-element-values title
                             [:head :meta [:name "twitter:title"]]
                             result
@@ -106,6 +117,11 @@
          (is (= description pg-desc tw-desc))
          (is (= pg-desc tw-desc))))))
   ([result title] (assert-twitter-card result title nil)))
+
+(defn assert-no-twitter-card [result title]
+  (testing (str title " should NOT have a twitter card")
+    (is nil? (find-element-by-path [:head :meta [:name "twitter:card"]]
+                                   result))))
 
 (deftest ^:unit format-pronoun-examples-page
   (let [result (pages/format-pronoun-examples
@@ -136,14 +152,11 @@
         title "Pronoun Island - Not Found :("]
     (assert-has-head-block result title)
     (assert-contact-block result title)
-    (is nil? (find-element-by-path [:head :meta [:name "twitter:card"]]
-                                   result))))
-
+    (assert-no-twitter-card result title)))
 
 (deftest ^:unit error*-page
   (let [result (pages/error* "/foo/bar")
         title "Pronoun Island - Error :("]
     (assert-has-head-block result title)
     (assert-contact-block result title)
-    (is nil? (find-element-by-path [:head :meta [:name "twitter:card"]]
-                                   result))))
+    (assert-no-twitter-card result title)))

--- a/test/pronouns/pages_test.clj
+++ b/test/pronouns/pages_test.clj
@@ -1,7 +1,9 @@
 (ns pronouns.pages-test
   (:require [pronouns.pages :as pages]
-            [clojure.test :refer [deftest testing are]]))
+            [clojure.walk :as walk]
+            [clojure.test :refer [deftest testing are is]]))
 
+;; Tests for page logic functions
 (deftest ^:unit prose-comma-list
   (testing "`prose-comma-list` turns a list of strings into a prose list"
     (are [v s] (= (pages/prose-comma-list v) s)
@@ -21,3 +23,127 @@
     ["she/her" "foo/bar"] '(["she" "her" "her" "hers" "herself"])
     ["foo/bar"]           '()
     ["a/b/c/d/e"]         '(("a" "b" "c" "d" "e"))))
+
+;; Tests for page construction
+(defn is-element? [tag form]
+  (when (and (vector? form)
+             (= (first form) tag))
+    form))
+
+(defn find-element-by-tag [tag form]
+  (walk/walk (partial is-element? tag)
+             (partial remove nil?)
+             form))
+
+(defn find-element-by-path
+  "Return the element at path in the body.
+
+  path - A sequence of lookup keys in traversal order
+         lookup keys can either be a keyword representing a tag,
+         or a [k v] pair to be found in an attributes map.
+
+         If a [k v] pair, the resulting attributes map will be returned
+         directly without traversing further.
+
+  body - A hiccup-style vector tree representing an HTML document"
+  [path body]
+  (if-let [key (first path)]
+    (if (vector? key)
+      (let [[k v] key]
+        (first (filter #(= v (k %)) body)))
+      (let [matches (find-element-by-tag key body)]
+        (recur (rest path) (apply concat matches))))
+    body))
+
+(defn assert-element-values
+  ([v path form key-fn]
+   (testing (str "Assert element values: " v path))
+   (is (= v
+          (key-fn
+           (find-element-by-path path form)))))
+  ([v path form]
+   (assert-element-values v path form identity)))
+
+(defn assert-has-head-block [result title]
+  (testing (str title " has head block")
+    (assert-element-values title [:head :title] result second)
+    (assert-element-values "/pronouns.css" [:head :link [:rel "stylesheet"]] result :href)
+    (assert-element-values "width=device-width"
+                           [:head :meta [:name "viewport"]]
+                           result
+                           :content)))
+
+(defn assert-contact-block [result title]
+  (testing (str title " has contact block")
+    (let [anchors (find-element-by-path [:body :footer :div :p :a]
+                                        result)
+          labels (into #{} (filter string? anchors))]
+      ;; (println title labels)
+      (is (labels "@morganastra"))
+      (is (labels "pronoun.is/she"))
+      (is (labels "AGPLv3"))
+      (is (labels "github")))))
+
+(defn assert-twitter-card
+  ([result title description]
+   (testing (str title " has twitter meta block")
+     (assert-element-values title
+                            [:head :meta [:name "twitter:title"]]
+                            result
+                            :content)
+     (assert-element-values "summary"
+                            [:head :meta [:name "twitter:card"]]
+                            result
+                            :content)
+     (let [pg-desc (:content (find-element-by-path [:head :meta [:name "description"]]
+                                                   result))
+           tw-desc (:content (find-element-by-path [:head :meta
+                                                    [:name "twitter:description"]]
+                                                   result))]
+       (is (string? pg-desc))
+       (is (string? tw-desc))
+       (if (some? description)
+         (is (= description pg-desc tw-desc))
+         (is (= pg-desc tw-desc))))))
+  ([result title] (assert-twitter-card result title nil)))
+
+(deftest ^:unit format-pronoun-examples-page
+  (let [result (pages/format-pronoun-examples
+                '(["she" "her" "her" "hers" "herself"]))
+        title "Pronoun Island: she/her examples"]
+    (assert-has-head-block result title)
+    (assert-twitter-card result title)
+    (assert-contact-block result title)))
+
+(deftest ^:unit front*-page
+  (let [result (pages/front*)
+        title "Pronoun Island"
+        description "Pronoun.is is a website for personal pronoun usage examples."]
+    (assert-has-head-block result title)
+    (assert-contact-block result title)
+    (assert-twitter-card result title description)))
+
+(deftest ^:unit all-pronouns*-page
+  (let [result (pages/all-pronouns*)
+        title "Pronoun Island"
+        description "Pronoun.is is a website for personal pronoun usage examples."]
+    (assert-has-head-block result title)
+    (assert-twitter-card result title description)
+    (assert-contact-block result title)))
+
+(deftest ^:unit not-found*-page
+  (let [result (pages/not-found* "/foo/bar")
+        title "Pronoun Island - Not Found :("]
+    (assert-has-head-block result title)
+    (assert-contact-block result title)
+    (is nil? (find-element-by-path [:head :meta [:name "twitter:card"]]
+                                   result))))
+
+
+(deftest ^:unit error*-page
+  (let [result (pages/error* "/foo/bar")
+        title "Pronoun Island - Error :("]
+    (assert-has-head-block result title)
+    (assert-contact-block result title)
+    (is nil? (find-element-by-path [:head :meta [:name "twitter:card"]]
+                                   result))))


### PR DESCRIPTION
## Give the user the most helpful message possible in the case of errors

* Generate appropriate error pages in case of 400- and 500-series errors.
* Always offer a link back to the front page if nothing else fails
* Do not serve hardcoded html error pages

## Make error-handling visible to our test suite

* Add some routes for testing errors
* Significant improvements to tests, including:
  * test coverage for all page construction functions
  * a new framework in e2e test to make adding tests for new routes extremely straightforward
  
### And incidentially...

* Add `lein preflight` alias to run everything CI does + `ancient` locally in one command
* Fixed some minor bugs that were surfaced by the new tests :)

The page construction fixes and new routes constitute a minor version bump - we will now be at 1.13.0